### PR TITLE
refactor: Extract service classes from MarkdownPlugin

### DIFF
--- a/class.MarkdownPlugin.php
+++ b/class.MarkdownPlugin.php
@@ -1,14 +1,5 @@
 <?php
 
-// Only include osTicket classes if they exist (not in test environment)
-if (defined('INCLUDE_DIR') && file_exists(INCLUDE_DIR . 'class.plugin.php')) {
-    require_once INCLUDE_DIR . 'class.plugin.php';
-}
-
-if (file_exists(__DIR__ . '/config.php')) {
-    require_once __DIR__ . '/config.php';
-}
-
 /**
  * Markdown Support Plugin for osTicket 1.18.x
  *
@@ -20,403 +11,311 @@ if (file_exists(__DIR__ . '/config.php')) {
  * - 2-layer XSS protection (Parsedown SafeMode + Format::sanitize())
  * - Email/PDF export support
  * - Search indexing support
- * - No core file modifications needed
+ * - No core file modifications needed (except one minimal patch)
+ *
+ * Architecture:
+ * - ConfigCache: Singleton for config caching (solves Signal callback issue)
+ * - CorePatcher: Handles Reflection and core file patching
+ * - AssetInjector: CSS/JS injection into pages
+ * - AssetDeployer: API file and .htaccess management
+ * - ThreadEntryHandler: Signal handlers for thread entries
+ * - MarkdownSanitizer: Unified XSS prevention
  */
-class MarkdownPlugin extends Plugin {
-    var $config_class = 'MarkdownConfig';
 
-    // CRITICAL FIX: Static config cache for Signal callbacks
-    // Signal callbacks get a new instance without proper config
-    // So we cache config values statically during bootstrap
-    static $cached_config = null;
+// Only include osTicket classes if they exist (not in test environment)
+if (defined('INCLUDE_DIR') && file_exists(INCLUDE_DIR . 'class.plugin.php')) {
+    require_once INCLUDE_DIR . 'class.plugin.php';
+}
+
+if (file_exists(__DIR__ . '/config.php')) {
+    require_once __DIR__ . '/config.php';
+}
+
+// Load new service classes
+require_once __DIR__ . '/vendor/autoload.php';
+
+use MarkdownSupport\Config\ConfigCache;
+use MarkdownSupport\Core\CorePatcher;
+use MarkdownSupport\Asset\AssetInjector;
+use MarkdownSupport\Asset\AssetDeployer;
+use MarkdownSupport\Signal\ThreadEntryHandler;
+
+/**
+ * Main plugin class
+ *
+ * Coordinates all plugin components and handles osTicket lifecycle events.
+ * Uses dependency injection pattern for better testability.
+ */
+class MarkdownPlugin extends Plugin
+{
+    /** @var string Configuration class name */
+    public $config_class = 'MarkdownConfig';
+
+    /** @var CorePatcher|null Core patcher instance */
+    private ?CorePatcher $corePatcher = null;
+
+    /** @var AssetInjector|null Asset injector instance */
+    private ?AssetInjector $assetInjector = null;
+
+    /** @var AssetDeployer|null Asset deployer instance */
+    private ?AssetDeployer $assetDeployer = null;
+
+    /** @var ThreadEntryHandler|null Thread entry handler instance */
+    private ?ThreadEntryHandler $threadEntryHandler = null;
 
     /**
      * Only one instance of this plugin makes sense
      */
-    function isSingleton() {
+    public function isSingleton(): bool
+    {
         return true;
     }
 
     /**
      * Bootstrap plugin - called when osTicket initializes
      */
-    function bootstrap() {
-        // Get config from the REAL instance (has proper ID)
-        $config = $this->getConfig();
-
-        // CRITICAL FIX: Cache config values statically for Signal callbacks
-        // Signal callbacks get a new instance without config, so they read from cache
-        self::$cached_config = [
-            'default_format' => $config->get('default_format'),
-            'allow_format_switch' => $config->get('allow_format_switch'),
-            'show_toolbar' => $config->get('show_toolbar'),
-            'installed_version' => $config->get('installed_version'),
-            // Deprecated: Kept for backward compatibility with old DB entries
-            'enable_debug_logging' => false
-        ];
-
-        // Version tracking and auto-update
+    public function bootstrap(): void
+    {
+        $this->initializeServices();
+        $this->populateConfigCache();
         $this->checkVersion();
-
-        // Deploy API file to /api/markdown/ (avoids /include/.htaccess issues)
-        $this->ensureApiFileDeployed();
+        $this->deployAssets();
 
         // Only proceed if plugin is enabled
-        $enabled = $config->get('enabled');
-
-        if (!$enabled) {
+        if (!$this->isEnabled()) {
             return;
         }
 
-        // CRITICAL: Extend ThreadEntryBody::$types with 'markdown' using Reflection
-        $this->extendThreadEntryTypes();
+        $this->extendCoreClasses();
+        $this->registerSignalHandlers();
+        $this->setupAssetInjection();
+    }
 
-        // Register custom MarkdownThreadEntryBody class
+    /**
+     * Initialize service instances
+     */
+    private function initializeServices(): void
+    {
+        $includeDir = defined('INCLUDE_DIR') ? INCLUDE_DIR : __DIR__ . '/mocks/';
+        $osticketRoot = dirname($includeDir);
+        $pluginUrl = $this->getPluginUrl();
+
+        $this->corePatcher = new CorePatcher($includeDir);
+        $this->assetDeployer = new AssetDeployer(__DIR__, $osticketRoot);
+        $this->assetInjector = new AssetInjector($pluginUrl, ConfigCache::getInstance());
+        $this->threadEntryHandler = new ThreadEntryHandler(
+            ConfigCache::getInstance(),
+            $this->createMarkdownDetector()
+        );
+    }
+
+    /**
+     * Populate config cache for Signal callbacks
+     *
+     * Signal callbacks receive new plugin instances without proper config.
+     * We cache config values statically to work around this osTicket limitation.
+     */
+    private function populateConfigCache(): void
+    {
+        $config = $this->getConfig();
+
+        ConfigCache::getInstance()->populate([
+            'default_format' => $config->get('default_format') ?? 'markdown',
+            'allow_format_switch' => $config->get('allow_format_switch') ?? true,
+            'show_toolbar' => $config->get('show_toolbar') ?? true,
+            'installed_version' => $config->get('installed_version') ?? '',
+            'auto_convert_to_markdown' => $config->get('auto_convert_to_markdown') ?? false,
+            'auto_detect_threshold' => 5,
+        ]);
+    }
+
+    /**
+     * Check if plugin is enabled
+     */
+    private function isEnabled(): bool
+    {
+        return (bool) $this->getConfig()->get('enabled');
+    }
+
+    /**
+     * Extend core osTicket classes
+     */
+    private function extendCoreClasses(): void
+    {
+        // Add 'markdown' to ThreadEntryBody::$types via Reflection
+        $this->corePatcher->extendThreadEntryTypes();
+
+        // Load MarkdownThreadEntryBody class
         $this->registerMarkdownBodyClass();
 
-        // CRITICAL: Patch ThreadEntryBody::fromFormattedText() to support 'markdown'
-        $this->patchFromFormattedTextIfNeeded();
+        // Patch class.thread.php for fromFormattedText() support
+        $this->corePatcher->patchFromFormattedText();
+    }
 
-        // Connect signals for UI integration
-        Signal::connect('object.view', array($this, 'onObjectView'));
+    /**
+     * Register Signal handlers
+     */
+    private function registerSignalHandlers(): void
+    {
+        // Asset injection when viewing tickets
+        Signal::connect('object.view', [$this, 'onObjectView']);
 
-        // Hook into thread entry creation for format correction
-        Signal::connect('threadentry.created', array($this, 'onThreadEntryCreated'));
+        // Format correction after thread entry creation
+        Signal::connect('threadentry.created', [$this, 'onThreadEntryCreated']);
+    }
 
-        // CRITICAL: Hook before thread entry is saved to fix format field
-        Signal::connect('model.created', array($this, 'onModelCreated'));
+    /**
+     * Setup asset injection via output buffering
+     */
+    private function setupAssetInjection(): void
+    {
+        // Skip AJAX requests
+        if ($this->assetInjector->isAjaxRequest()) {
+            return;
+        }
 
-        // CRITICAL: Inject assets on ALL ticket-related pages
-        // object.view only fires when viewing existing objects, not on "New Ticket" form
-        // So we inject assets directly here if we're on a relevant page
-        // IMPORTANT: Skip AJAX requests to avoid interfering with ticket locking
-        $isAjax = !empty($_SERVER['HTTP_X_REQUESTED_WITH']) &&
-                  strtolower($_SERVER['HTTP_X_REQUESTED_WITH']) === 'xmlhttprequest';
-
-        if ($this->isEditorPage() && !$isAjax) {
-            // Use output buffering to inject assets at the right time
-            ob_start(array($this, 'injectAssetsIntoOutput'));
+        // Only inject on editor pages
+        if ($this->assetInjector->isEditorPage()) {
+            ob_start([$this->assetInjector, 'injectAssetsIntoOutput']);
         }
     }
 
     /**
-     * Extend ThreadEntryBody::$types array using Reflection
-     *
-     * This is the CORE technique that allows us to add 'markdown' as a valid
-     * ThreadEntryBody type WITHOUT modifying core files.
+     * Deploy plugin assets
      */
-    function extendThreadEntryTypes() {
-        // Check if ThreadEntryBody class exists
-        if (!class_exists('ThreadEntryBody')) {
-            error_log('[Markdown-Support] Warning: ThreadEntryBody class not found');
-            return;
-        }
-
-        try {
-            $reflection = new ReflectionClass('ThreadEntryBody');
-            $types_prop = $reflection->getProperty('types');
-            $types_prop->setAccessible(true);
-
-            $types = $types_prop->getValue();
-
-            // Add 'markdown' if not already present
-            if (!in_array('markdown', $types)) {
-                $types[] = 'markdown';
-                $types_prop->setValue(null, $types);
-            }
-        } catch (ReflectionException $e) {
-            error_log('[Markdown-Support] Failed to extend ThreadEntryBody::$types: ' . $e->getMessage());
-        }
-    }
-
-    /**
-     * Register MarkdownThreadEntryBody class
-     */
-    function registerMarkdownBodyClass() {
-        // Load MarkdownThreadEntryBody class
-        $body_file = __DIR__ . '/markdown-body.php';
-
-        if (!file_exists($body_file)) {
-            error_log('[Markdown-Support] Warning: markdown-body.php not found');
-            return;
-        }
-
-        require_once $body_file;
-
-        // Verify class was loaded
-        if (!class_exists('MarkdownThreadEntryBody')) {
-            error_log('[Markdown-Support] Warning: MarkdownThreadEntryBody class not found');
-            return;
-        }
-    }
-
-    /**
-     * Patches ThreadEntryBody::fromFormattedText() to support 'markdown' format
-     *
-     * This is a minimal, safe patch that adds one case statement to class.thread.php
-     */
-    function patchFromFormattedTextIfNeeded() {
-        $thread_file = INCLUDE_DIR . 'class.thread.php';
-
-        if (!file_exists($thread_file)) {
-            error_log('[Markdown-Support] Error: class.thread.php not found');
-            return false;
-        }
-
-        $content = file_get_contents($thread_file);
-
-        // Check if already patched
-        if (strpos($content, "case 'markdown':") !== false) {
-            return true;
-        }
-
-        // Create backup
-        $backup_file = $thread_file . '.markdown-backup';
-        if (!file_exists($backup_file)) {
-            if (!copy($thread_file, $backup_file)) {
-                error_log('[Markdown-Support] Error: Failed to create backup');
-                return false;
-            }
-        }
-
-        // Patch: Add 'markdown' case to fromFormattedText()
-        $search = "case 'html':\n            return new HtmlThreadEntryBody(\$text, array('strip-embedded'=>false) + \$options);";
-        $replace = "case 'html':\n            return new HtmlThreadEntryBody(\$text, array('strip-embedded'=>false) + \$options);\n        case 'markdown':\n            return new MarkdownThreadEntryBody(\$text, \$options);";
-
-        $patched_content = str_replace($search, $replace, $content);
-
-        if ($patched_content === $content) {
-            error_log('[Markdown-Support] Warning: Patch pattern not found, trying alternative...');
-
-            // Alternative pattern (different whitespace)
-            $search = "case 'html':\n                return new HtmlThreadEntryBody(\$text, array('strip-embedded'=>false) + \$options);";
-            $replace = "case 'html':\n                return new HtmlThreadEntryBody(\$text, array('strip-embedded'=>false) + \$options);\n            case 'markdown':\n                return new MarkdownThreadEntryBody(\$text, \$options);";
-
-            $patched_content = str_replace($search, $replace, $content);
-        }
-
-        if ($patched_content === $content) {
-            error_log('[Markdown-Support] Error: Unable to apply patch');
-            return false;
-        }
-
-        // Write patched file
-        if (file_put_contents($thread_file, $patched_content) === false) {
-            error_log('[Markdown-Support] Error: Failed to write patched file');
-            return false;
-        }
-
-        return true;
+    private function deployAssets(): void
+    {
+        $this->assetDeployer->deployApiFile();
     }
 
     /**
      * Check plugin version and perform updates if needed
      */
-    function checkVersion() {
-        $plugin_file = INCLUDE_DIR . 'plugins/' . basename(dirname(__FILE__)) . '/plugin.php';
+    private function checkVersion(): void
+    {
+        $pluginFile = $this->getPluginPhpPath();
 
-        if (!file_exists($plugin_file)) {
-            error_log('[Markdown-Support] plugin.php not found');
+        if (!file_exists($pluginFile)) {
             return;
         }
 
-        $plugin_info = include($plugin_file);
-        $current_version = $plugin_info['version'];
-        $installed_version = $this->getConfig()->get('installed_version');
+        $pluginInfo = include($pluginFile);
+        $currentVersion = $pluginInfo['version'] ?? '0.0.0';
+        $installedVersion = $this->getConfig()->get('installed_version') ?? '';
 
-        if (!$installed_version || version_compare($installed_version, $current_version, '<')) {
-            $this->performUpdate($installed_version, $current_version);
+        if (!$installedVersion || version_compare($installedVersion, $currentVersion, '<')) {
+            $this->performUpdate($installedVersion, $currentVersion);
         }
-    }
-
-    /**
-     * Ensure API file is deployed to /api/
-     *
-     * Automatically copies markdown-preview.php from plugin directory to
-     * /api/markdown-preview.php to avoid Apache "Deny from all" in /include/
-     *
-     * This eliminates the need for modifying osTicket core .htaccess files.
-     */
-    function ensureApiFileDeployed() {
-        // Source: Plugin directory
-        $source_file = __DIR__ . '/markdown-preview.php';
-
-        // Target: /api/markdown-preview.php (same level as wildcard.php)
-        // Use INCLUDE_DIR to get filesystem path (not ROOT_PATH which is URL path)
-        $osticket_root = dirname(INCLUDE_DIR);
-        $api_dir = $osticket_root . '/api';
-        $target_file = $api_dir . '/markdown-preview.php';
-
-        // Check if source exists
-        if (!file_exists($source_file)) {
-            error_log('[Markdown-Support] Warning: markdown-preview.php not found in plugin directory');
-            return false;
-        }
-
-        // Check if API directory exists
-        if (!is_dir($api_dir)) {
-            error_log('[Markdown-Support] Error: /api directory not found');
-            return false;
-        }
-
-        // Check if target exists and is up-to-date
-        if (file_exists($target_file)) {
-            // Compare file hashes to detect changes
-            $source_hash = md5_file($source_file);
-            $target_hash = md5_file($target_file);
-
-            if ($source_hash === $target_hash) {
-                // File already up-to-date
-                return true;
-            }
-        }
-
-        // Copy file to target location
-        if (!@copy($source_file, $target_file)) {
-            error_log('[Markdown-Support] Error: Cannot copy API file to ' . $target_file . ' - check permissions');
-            return false;
-        }
-
-        // Set proper permissions
-        @chmod($target_file, 0644);
-
-        return true;
-    }
-
-    /**
-     * Debug logging function (disabled - no longer functional)
-     *
-     * @param string $message Log message
-     * @param string $level Log level (INFO, DEBUG, ERROR, WARNING)
-     * @param array $context Additional context data
-     * @deprecated Debug logging has been removed from production code
-     */
-    static function debugLog($message, $level = 'DEBUG', $context = []) {
-        // No-op: Debug logging disabled
-        // Kept for backward compatibility but does nothing
-        return;
     }
 
     /**
      * Perform plugin update
      */
-    function performUpdate($from_version, $to_version) {
-        // Update /include/.htaccess to allow static assets
-        $this->updateIncludeHtaccess();
-
-        // Deploy/update API file to /api/ directory
-        $this->ensureApiFileDeployed();
-
-        // Save new version
-        $this->getConfig()->set('installed_version', $to_version);
+    private function performUpdate(string $fromVersion, string $toVersion): void
+    {
+        $this->assetDeployer->updateIncludeHtaccess();
+        $this->assetDeployer->deployApiFile();
+        $this->getConfig()->set('installed_version', $toVersion);
     }
 
     /**
-     * Update /include/.htaccess to allow static assets for plugins
-     * Supports both Apache 2.2 and 2.4 syntax
+     * Register MarkdownThreadEntryBody class
      */
-    function updateIncludeHtaccess() {
-        $htaccess_file = INCLUDE_DIR . '.htaccess';
+    private function registerMarkdownBodyClass(): void
+    {
+        $bodyFile = __DIR__ . '/markdown-body.php';
 
-        if (!file_exists($htaccess_file)) {
-            error_log('[Markdown-Support] Warning: /include/.htaccess not found');
+        if (!file_exists($bodyFile)) {
+            error_log('[Markdown-Support] Warning: markdown-body.php not found');
             return;
         }
 
-        $htaccess_content = file_get_contents($htaccess_file);
-
-        // Check if plugin PHP rule already exists
-        if (strpos($htaccess_content, 'Allow PHP API endpoints in plugin directories') !== false) {
-            return;
-        }
-
-        // Find insertion point - either Apache 2.4 style or 2.2 style
-        // Look for the end of the deny block (either </IfModule> or "Deny from all")
-        $pattern = null;
-        if (preg_match('/(# Apache 2\.2\s+<IfModule !mod_authz_core\.c>.*?<\/IfModule>)/s', $htaccess_content)) {
-            // Apache 2.4 compatible format with IfModule blocks
-            $pattern = '/(# Apache 2\.2\s+<IfModule !mod_authz_core\.c>.*?<\/IfModule>)/s';
-        } elseif (preg_match('/(Deny from all)/', $htaccess_content)) {
-            // Old Apache 2.2 format
-            $pattern = '/(Deny from all)/';
-        }
-
-        if (!$pattern || !preg_match($pattern, $htaccess_content)) {
-            error_log('[Markdown-Support] Could not find insertion point in /include/.htaccess');
-            return;
-        }
-
-        // Generate Apache 2.2 and 2.4 compatible rules
-        $new_rule = "\n\n# Allow static assets and API endpoints for plugins\n";
-        $new_rule .= "<FilesMatch \"\\.(js|css|map|json|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|otf)\$\">\n";
-        $new_rule .= "    # Apache 2.4\n";
-        $new_rule .= "    <IfModule mod_authz_core.c>\n";
-        $new_rule .= "        Require all granted\n";
-        $new_rule .= "    </IfModule>\n\n";
-        $new_rule .= "    # Apache 2.2\n";
-        $new_rule .= "    <IfModule !mod_authz_core.c>\n";
-        $new_rule .= "        Order allow,deny\n";
-        $new_rule .= "        Allow from all\n";
-        $new_rule .= "    </IfModule>\n";
-        $new_rule .= "</FilesMatch>\n\n";
-        $new_rule .= "# Allow PHP API endpoints in plugin directories\n";
-        $new_rule .= "<FilesMatch \"^plugins/.+\\.php\$\">\n";
-        $new_rule .= "    # Apache 2.4\n";
-        $new_rule .= "    <IfModule mod_authz_core.c>\n";
-        $new_rule .= "        Require all granted\n";
-        $new_rule .= "    </IfModule>\n\n";
-        $new_rule .= "    # Apache 2.2\n";
-        $new_rule .= "    <IfModule !mod_authz_core.c>\n";
-        $new_rule .= "        Order allow,deny\n";
-        $new_rule .= "        Allow from all\n";
-        $new_rule .= "    </IfModule>\n";
-        $new_rule .= "</FilesMatch>";
-
-        $new_content = preg_replace(
-            $pattern,
-            "$1" . $new_rule,
-            $htaccess_content,
-            1 // Only replace first occurrence
-        );
-
-        if (!file_put_contents($htaccess_file, $new_content)) {
-            error_log('[Markdown-Support] Failed to update .htaccess');
-        }
+        require_once $bodyFile;
     }
+
+    /**
+     * Create MarkdownDetector instance for auto-detection
+     */
+    private function createMarkdownDetector(): ?object
+    {
+        $detectorFile = __DIR__ . '/MarkdownDetector.php';
+
+        if (!file_exists($detectorFile)) {
+            return null;
+        }
+
+        require_once $detectorFile;
+
+        if (!class_exists('MarkdownDetector')) {
+            return null;
+        }
+
+        return new \MarkdownDetector();
+    }
+
+    /**
+     * Get path to plugin.php
+     */
+    private function getPluginPhpPath(): string
+    {
+        if (defined('INCLUDE_DIR')) {
+            return INCLUDE_DIR . 'plugins/' . basename(__DIR__) . '/plugin.php';
+        }
+
+        return __DIR__ . '/plugin.php';
+    }
+
+    /**
+     * Get plugin base URL
+     */
+    public function getPluginUrl(): string
+    {
+        $pluginDir = basename(__DIR__);
+        $rootPath = defined('ROOT_PATH') ? ROOT_PATH : '/';
+
+        return $rootPath . 'include/plugins/' . $pluginDir;
+    }
+
+    // =========================================================================
+    // Plugin Lifecycle Methods (called by osTicket)
+    // =========================================================================
 
     /**
      * Called when plugin is enabled in admin panel
      */
-    function enable() {
-        $errors = array();
+    public function enable()
+    {
+        $errors = [];
 
         // Auto-create instance for singleton plugin
         if ($this->isSingleton() && $this->getNumInstances() === 0) {
-            $vars = array(
+            $vars = [
                 'name' => $this->getName(),
                 'isactive' => 1,
-                'notes' => 'Auto-created singleton instance'
-            );
+                'notes' => 'Auto-created singleton instance',
+            ];
 
             if (!$this->addInstance($vars, $errors)) {
-                error_log(sprintf('[Markdown-Support] Failed to auto-create instance: %s',
-                    json_encode($errors)));
+                error_log(sprintf(
+                    '[Markdown-Support] Failed to auto-create instance: %s',
+                    json_encode($errors)
+                ));
                 return $errors;
             }
         }
 
-        // Update /include/.htaccess to allow static assets for plugins
-        $this->updateIncludeHtaccess();
+        // Initialize services for enable operations
+        $this->initializeServices();
 
-        // Deploy API file to /api/ directory
-        $this->ensureApiFileDeployed();
+        // Deploy assets
+        $this->assetDeployer->updateIncludeHtaccess();
+        $this->assetDeployer->deployApiFile();
 
-        // Get current version from plugin.php
-        $plugin_file = INCLUDE_DIR . 'plugins/' . basename(dirname(__FILE__)) . '/plugin.php';
-
-        if (file_exists($plugin_file)) {
-            $plugin_info = include($plugin_file);
-            $this->getConfig()->set('installed_version', $plugin_info['version']);
+        // Save current version
+        $pluginFile = $this->getPluginPhpPath();
+        if (file_exists($pluginFile)) {
+            $pluginInfo = include($pluginFile);
+            $this->getConfig()->set('installed_version', $pluginInfo['version'] ?? '1.0.0');
         }
 
         return empty($errors) ? true : $errors;
@@ -425,350 +324,74 @@ class MarkdownPlugin extends Plugin {
     /**
      * Called when plugin is disabled in admin panel
      */
-    function disable() {
-        // Restore original class.thread.php from backup
-        $thread_file = INCLUDE_DIR . 'class.thread.php';
-        $backup_file = $thread_file . '.markdown-backup';
+    public function disable(): bool
+    {
+        // Initialize services for disable operations
+        $this->initializeServices();
 
-        if (file_exists($backup_file)) {
-            if (copy($backup_file, $thread_file)) {
-                unlink($backup_file); // Remove backup after restore
-            } else {
-                error_log('[Markdown-Support] Error: Failed to restore backup');
-            }
-        }
+        // Restore original core files
+        $this->corePatcher->restoreFromBackup();
 
-        // Remove API file from /api/ directory
-        $osticket_root = dirname(INCLUDE_DIR);
-        $api_file = $osticket_root . '/api/markdown-preview.php';
-
-        if (file_exists($api_file)) {
-            if (!@unlink($api_file)) {
-                error_log('[Markdown-Support] Warning: Could not remove API file: ' . $api_file);
-            }
-        }
-
-        // Remove static assets rule from /include/.htaccess
-        $htaccess_file = INCLUDE_DIR . '.htaccess';
-
-        if (file_exists($htaccess_file)) {
-            $htaccess_content = file_get_contents($htaccess_file);
-
-            // Check if our rules exist
-            if (strpos($htaccess_content, 'Allow static assets and API endpoints') !== false ||
-                strpos($htaccess_content, 'Allow static assets for plugins') !== false) {
-                // Remove all FilesMatch blocks we added (both old and new format)
-                $pattern = '/\n\n# Allow static assets (and API endpoints )?for plugins.*?<\/FilesMatch>(\n\n# Allow PHP API endpoints.*?<\/FilesMatch>)?/s';
-                $new_content = preg_replace($pattern, '', $htaccess_content);
-
-                if (!file_put_contents($htaccess_file, $new_content)) {
-                    error_log('[Markdown-Support] Failed to remove .htaccess rule');
-                }
-            }
-        }
+        // Remove deployed assets
+        $this->assetDeployer->removeApiFile();
+        $this->assetDeployer->removeHtaccessRules();
 
         return true;
     }
 
+    // =========================================================================
+    // Signal Handlers
+    // =========================================================================
+
     /**
      * Signal handler for object.view
      *
-     * Injects Markdown editor assets when viewing tickets
-     * Note: This runs AFTER jQuery is loaded but BEFORE page rendering completes
+     * Injects Markdown editor assets when viewing tickets.
      *
      * @param object $object The object being viewed (Ticket, Task, etc.)
      */
-    function onObjectView($object) {
-        // Only handle Ticket objects
+    public function onObjectView($object): void
+    {
         if (!($object instanceof Ticket)) {
             return;
         }
 
-        // Inject assets (CSS/JS available, jQuery loaded at this point)
-        $this->injectEditorAssets();
-    }
-
-    /**
-     * Detect if we're on a page that needs the Markdown editor
-     *
-     * @return bool
-     */
-    function isEditorPage() {
-        // Check for common editor pages
-        $script = basename($_SERVER['SCRIPT_NAME']);
-        $action = $_GET['a'] ?? '';
-
-        // Pages that need the editor:
-        // - tickets.php?a=open (New Ticket)
-        // - tickets.php?id=123 (View Ticket with reply)
-        // - tickets.php (Ticket listing page - might have quick reply)
-        return $script === 'tickets.php'
-            || $script === 'ticket.php'
-            || ($script === 'ajax.php' && strpos($_SERVER['REQUEST_URI'], 'ticket') !== false);
+        $this->assetInjector->injectAssets();
     }
 
     /**
      * Signal handler for threadentry.created
      *
-     * Post-processes thread entries for Markdown conversion
+     * Delegates to ThreadEntryHandler for format detection and correction.
      *
-     * @param ThreadEntry $entry The created thread entry
+     * @param object $entry The created thread entry
      */
-    function onThreadEntryCreated($entry) {
-        // CRITICAL FIX: Restore newlines that get stripped during osTicket's save process
-        // osTicket's ThreadEntry save sometimes removes newlines from body content
-        $body = $entry->getBody();
+    public function onThreadEntryCreated($entry): void
+    {
+        $this->threadEntryHandler->onThreadEntryCreated($entry);
+    }
 
-        // Check POST data for newlines and restore if they were lost
-        $postBodyFields = array('response', 'note', 'message', 'body');
-        foreach ($postBodyFields as $field) {
-            if (isset($_POST[$field])) {
-                $postBody = $_POST[$field];
+    // =========================================================================
+    // Backward Compatibility
+    // =========================================================================
 
-                // If newlines are in POST but not in saved entry, restore them
-                if (strpos($postBody, "\n") !== false && strpos($body, "\n") === false) {
-                    // Update body directly in database with POST data
-                    $sql = 'UPDATE ' . THREAD_ENTRY_TABLE .
-                           ' SET body = ' . db_input($postBody) .
-                           ' WHERE id = ' . db_input($entry->getId());
-
-                    db_query($sql);
-                }
-                break; // Only check first matching field
-            }
-        }
-
-        // Check if this entry should be markdown
-        $format = null;
-
-        // Check POST data (form submissions)
-        if (isset($_POST['format'])) {
-            $format = $_POST['format'];
-        }
-
-        // Check JSON body (API requests)
-        // Only read JSON if we don't have format from POST and Content-Type is JSON
-        if (!$format) {
-            $content_type = $_SERVER['CONTENT_TYPE'] ?? '';
-
-            if (strpos($content_type, 'application/json') !== false) {
-                $json_input = file_get_contents('php://input');
-                if ($json_input) {
-                    $data = json_decode($json_input, true);
-                    if (isset($data['format'])) {
-                        $format = $data['format'];
-                    }
-                }
-            }
-        }
-
-        // If markdown format detected, update entry
-        if ($format === 'markdown') {
-            // Get current format from entry
-            $current_format = $entry->get('format');
-
-            if ($current_format !== 'markdown') {
-                // Update format directly in database
-                $sql = 'UPDATE ' . THREAD_ENTRY_TABLE .
-                       ' SET format = "markdown"' .
-                       ' WHERE id = ' . db_input($entry->getId());
-
-                if (!db_query($sql)) {
-                    error_log("[Markdown-Support] Failed to update format: " . db_error());
-                }
-            }
-        }
-
-        // Auto-conversion: Detect and convert Markdown syntax automatically
-        if ($this->getConfig()->get('auto_convert_to_markdown')) {
-            // Only auto-detect if format was not explicitly set
-            if (!isset($_POST['format']) || empty($_POST['format'])) {
-                // Load TicketFormatHandler for auto-detection
-                require_once __DIR__ . '/TicketFormatHandler.php';
-                require_once __DIR__ . '/MarkdownDetector.php';
-
-                // Prepare config for handler
-                $config = array(
-                    'auto_convert_to_markdown' => true,
-                    'auto_detect_threshold' => 5, // 5% confidence minimum
-                    'default_format' => $this->getConfig()->get('default_format') ?: 'html'
-                );
-
-                $handler = new TicketFormatHandler($config);
-
-                // Check if we should convert to markdown
-                $postBodyFields = array('response', 'note', 'message', 'body');
-                foreach ($postBodyFields as $field) {
-                    if (isset($_POST[$field])) {
-                        $detectedFormat = $handler->determineFormat(array(
-                            'message' => $_POST[$field]
-                        ));
-
-                        if ($detectedFormat === 'markdown') {
-                            $current_format = $entry->get('format');
-
-                            if ($current_format !== 'markdown') {
-                                self::debugLog("Auto-detected Markdown syntax, converting entry #{$entry->getId()} from '{$current_format}' to 'markdown'", 'INFO');
-
-                                // Update format to markdown
-                                $sql = 'UPDATE ' . THREAD_ENTRY_TABLE .
-                                       ' SET format = "markdown"' .
-                                       ' WHERE id = ' . db_input($entry->getId());
-
-                                db_query($sql);
-                            }
-                        }
-                        break;
-                    }
-                }
-            }
-        }
+    /**
+     * Debug logging function (deprecated)
+     *
+     * @deprecated Debug logging has been removed from production code
+     */
+    public static function debugLog(string $message, string $level = 'DEBUG', array $context = []): void
+    {
+        // No-op: Kept for backward compatibility
     }
 
     /**
-     * Hook for model.created signal - fixes format before save
+     * Legacy static config cache access
+     *
+     * @deprecated Use ConfigCache::getInstance() instead
      */
-    function onModelCreated($model) {
-        // This runs after the model is created, so we use onThreadEntryCreated instead
-    }
-
-    /**
-     * Inject Markdown editor assets (JavaScript, CSS)
-     *
-     * CRITICAL: Assets are loaded on ALL pages for reliability.
-     * - CSS MUST be in <head> to prevent FOUC (Flash of Unstyled Content)
-     * - JS initializes intelligently (only on ticket pages)
-     * - Total size: ~20KB (negligible performance impact)
-     *
-     * Why not use Signals?
-     * - object.view: Too late (page already rendered, Redactor initialized)
-     * - assets.ready: Does not exist in osTicket
-     * - No osTicket signal fires BEFORE page render but ONLY on ticket pages
-     */
-    function injectEditorAssets() {
-        // CRITICAL FIX: Use cached config from bootstrap instead of getConfig()
-        // Signal callbacks get a new instance without proper config ID
-        // So we read from static cache populated in bootstrap()
-        if (self::$cached_config) {
-            // Use cached values from bootstrap (has correct config ID)
-            $default_format = self::$cached_config['default_format'] ?: 'markdown';
-            $allow_format_switch = self::$cached_config['allow_format_switch'];
-            $show_toolbar = self::$cached_config['show_toolbar'];
-            $version = self::$cached_config['installed_version'];
-        } else {
-            // Fallback: Try to get config (might be empty instance)
-            $config_obj = $this->getConfig();
-            $default_format = $config_obj->get('default_format') ?: 'markdown';
-            $allow_format_switch = $config_obj->get('allow_format_switch');
-            $show_toolbar = $config_obj->get('show_toolbar');
-            $version = $config_obj->get('installed_version');
-        }
-
-        // Build asset URLs with cache-busting
-        $plugin_url = $this->getPluginUrl();
-        $cache_param = $version ? '?v=' . urlencode($version) : '';
-        $css_url = $plugin_url . '/css/markdown-editor.css' . $cache_param;
-        $js_url = $plugin_url . '/js/markdown-editor.js' . $cache_param;
-
-        // Inject config as global JavaScript variable (before editor JS loads)
-        // Using PHP output instead of echo for better control
-        $preview_api_url = ROOT_PATH . 'api/markdown-preview.php';
-        ?>
-<script>
-window.osTicketMarkdownConfig = {
-    defaultFormat: <?php echo json_encode($default_format); ?>,
-    allowFormatSwitch: <?php echo json_encode((bool)$allow_format_switch); ?>,
-    showToolbar: <?php echo json_encode((bool)$show_toolbar); ?>,
-    previewApiUrl: <?php echo json_encode($preview_api_url); ?>
-};
-</script>
-<link rel="stylesheet" href="<?php echo htmlspecialchars($css_url, ENT_QUOTES, 'UTF-8'); ?>">
-<script defer src="<?php echo htmlspecialchars($js_url, ENT_QUOTES, 'UTF-8'); ?>"></script>
-<?php
-    }
-
-    /**
-     * Get plugin base URL
-     *
-     * @return string Plugin URL (e.g., /include/plugins/markdown-support)
-     */
-    function getPluginUrl() {
-        $plugin_dir = basename(dirname(__FILE__));
-        return ROOT_PATH . 'include/plugins/' . $plugin_dir;
-    }
-
-    /**
-     * Get editor assets as HTML string
-     *
-     * Returns the same output as injectEditorAssets() but as a string
-     * instead of directly echoing. Used in output buffer handler.
-     *
-     * @return string HTML with CSS/JS tags
-     */
-    function getEditorAssetsHtml() {
-        // Get config values (same logic as injectEditorAssets)
-        if (self::$cached_config) {
-            $default_format = self::$cached_config['default_format'] ?: 'markdown';
-            $allow_format_switch = self::$cached_config['allow_format_switch'];
-            $show_toolbar = self::$cached_config['show_toolbar'];
-            $version = self::$cached_config['installed_version'];
-        } else {
-            $config_obj = $this->getConfig();
-            $default_format = $config_obj->get('default_format') ?: 'markdown';
-            $allow_format_switch = $config_obj->get('allow_format_switch');
-            $show_toolbar = $config_obj->get('show_toolbar');
-            $version = $config_obj->get('installed_version');
-        }
-
-        // Build asset URLs
-        $plugin_url = $this->getPluginUrl();
-        $cache_param = $version ? '?v=' . urlencode($version) : '';
-        $css_url = $plugin_url . '/css/markdown-editor.css' . $cache_param;
-        $js_url = $plugin_url . '/js/markdown-editor.js' . $cache_param;
-        $preview_api_url = ROOT_PATH . 'api/markdown-preview.php';
-
-        // Build HTML as string
-        $html = "<script>\n";
-        $html .= "window.osTicketMarkdownConfig = {\n";
-        $html .= "    defaultFormat: " . json_encode($default_format) . ",\n";
-        $html .= "    allowFormatSwitch: " . json_encode((bool)$allow_format_switch) . ",\n";
-        $html .= "    showToolbar: " . json_encode((bool)$show_toolbar) . ",\n";
-        $html .= "    previewApiUrl: " . json_encode($preview_api_url) . "\n";
-        $html .= "};\n";
-        $html .= "</script>\n";
-        $html .= "<link rel=\"stylesheet\" href=\"" . htmlspecialchars($css_url, ENT_QUOTES, 'UTF-8') . "\">\n";
-        $html .= "<script src=\"" . htmlspecialchars($js_url, ENT_QUOTES, 'UTF-8') . "\"></script>\n";
-
-        return $html;
-    }
-
-    /**
-     * Output buffer callback to inject assets into HTML output
-     *
-     * This is used when we can't rely on object.view signal (e.g., New Ticket form)
-     *
-     * @param string $buffer HTML output buffer
-     * @return string Modified HTML with injected assets
-     */
-    function injectAssetsIntoOutput($buffer) {
-        // Only inject if we haven't already (prevent double injection)
-        if (strpos($buffer, 'window.osTicketMarkdownConfig') !== false) {
-            return $buffer;
-        }
-
-        // Get asset HTML as string (no ob_start needed!)
-        $assets = $this->getEditorAssetsHtml();
-
-        // Inject before </head> if possible, otherwise before </body>
-        if (stripos($buffer, '</head>') !== false) {
-            $buffer = str_ireplace('</head>', $assets . '</head>', $buffer);
-        } elseif (stripos($buffer, '</body>') !== false) {
-            $buffer = str_ireplace('</body>', $assets . '</body>', $buffer);
-        } else {
-            // No closing tags found, append to end
-            $buffer .= $assets;
-        }
-
-        return $buffer;
+    public static function getCachedConfig(): array
+    {
+        return ConfigCache::getInstance()->all();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,15 @@
   },
   "autoload": {
     "psr-4": {
-      "MarkdownSupport\\": "./"
-    }
+      "MarkdownSupport\\": "src/"
+    },
+    "classmap": [
+      "class.MarkdownPlugin.php",
+      "config.php",
+      "MarkdownDetector.php",
+      "TicketFormatHandler.php",
+      "markdown-body.php"
+    ]
   },
   "autoload-dev": {
     "psr-4": {

--- a/src/Asset/AssetDeployer.php
+++ b/src/Asset/AssetDeployer.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkdownSupport\Asset;
+
+/**
+ * AssetDeployer - Deploys plugin assets to accessible locations
+ *
+ * Handles:
+ * - API file deployment to /api/ directory
+ * - .htaccess updates for static asset access
+ * - File permission management
+ *
+ * @package MarkdownSupport
+ */
+final class AssetDeployer
+{
+    private string $pluginDir;
+    private string $osticketRoot;
+
+    public function __construct(string $pluginDir, string $osticketRoot)
+    {
+        $this->pluginDir = rtrim($pluginDir, '/');
+        $this->osticketRoot = rtrim($osticketRoot, '/');
+    }
+
+    /**
+     * Deploy API endpoint file to /api/ directory
+     *
+     * Copies markdown-preview.php from plugin to /api/ to avoid
+     * Apache "Deny from all" restrictions in /include/.htaccess
+     *
+     * @return bool True if deployment successful
+     */
+    public function deployApiFile(): bool
+    {
+        $sourceFile = $this->pluginDir . '/markdown-preview.php';
+        $apiDir = $this->osticketRoot . '/api';
+        $targetFile = $apiDir . '/markdown-preview.php';
+
+        if (!file_exists($sourceFile)) {
+            $this->log('Warning: markdown-preview.php not found in plugin directory');
+            return false;
+        }
+
+        if (!is_dir($apiDir)) {
+            $this->log('Error: /api directory not found');
+            return false;
+        }
+
+        // Check if target is up-to-date
+        if (file_exists($targetFile)) {
+            $sourceHash = md5_file($sourceFile);
+            $targetHash = md5_file($targetFile);
+
+            if ($sourceHash === $targetHash) {
+                return true; // Already up-to-date
+            }
+        }
+
+        // Copy file
+        if (!@copy($sourceFile, $targetFile)) {
+            $this->log('Error: Cannot copy API file to ' . $targetFile);
+            return false;
+        }
+
+        // Set permissions
+        if (!@chmod($targetFile, 0644)) {
+            $this->log('Warning: Failed to set permissions on API file');
+        }
+
+        return true;
+    }
+
+    /**
+     * Remove deployed API file
+     *
+     * @return bool True if removal successful
+     */
+    public function removeApiFile(): bool
+    {
+        $apiFile = $this->osticketRoot . '/api/markdown-preview.php';
+
+        if (!file_exists($apiFile)) {
+            return true; // Already removed
+        }
+
+        if (!@unlink($apiFile)) {
+            $this->log('Warning: Could not remove API file: ' . $apiFile);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Update /include/.htaccess to allow static assets for plugins
+     *
+     * Adds FilesMatch rules for CSS, JS, images, and fonts.
+     *
+     * @return bool True if update successful
+     */
+    public function updateIncludeHtaccess(): bool
+    {
+        $htaccessFile = $this->osticketRoot . '/include/.htaccess';
+
+        if (!file_exists($htaccessFile)) {
+            $this->log('Warning: /include/.htaccess not found');
+            return false;
+        }
+
+        $content = file_get_contents($htaccessFile);
+        if ($content === false) {
+            $this->log('Error: Cannot read /include/.htaccess');
+            return false;
+        }
+
+        // Check if already updated
+        if (strpos($content, 'Allow PHP API endpoints in plugin directories') !== false) {
+            return true;
+        }
+
+        // Find insertion point
+        $insertionPoint = $this->findInsertionPoint($content);
+        if ($insertionPoint === null) {
+            $this->log('Could not find insertion point in /include/.htaccess');
+            return false;
+        }
+
+        // Generate new rules
+        $newRules = $this->generateHtaccessRules();
+
+        // Insert rules
+        $newContent = preg_replace(
+            $insertionPoint['pattern'],
+            $insertionPoint['match'] . $newRules,
+            $content,
+            1
+        );
+
+        if ($newContent === null || $newContent === $content) {
+            $this->log('Error: Failed to insert .htaccess rules');
+            return false;
+        }
+
+        if (file_put_contents($htaccessFile, $newContent) === false) {
+            $this->log('Error: Failed to write .htaccess');
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Remove plugin rules from /include/.htaccess
+     *
+     * @return bool True if removal successful
+     */
+    public function removeHtaccessRules(): bool
+    {
+        $htaccessFile = $this->osticketRoot . '/include/.htaccess';
+
+        if (!file_exists($htaccessFile)) {
+            return true;
+        }
+
+        $content = file_get_contents($htaccessFile);
+        if ($content === false) {
+            return false;
+        }
+
+        // Remove all our FilesMatch blocks
+        $pattern = '/\n\n# Allow static assets (and API endpoints )?for plugins.*?<\/FilesMatch>(\n\n# Allow PHP API endpoints.*?<\/FilesMatch>)?/s';
+        $newContent = preg_replace($pattern, '', $content);
+
+        if ($newContent === $content) {
+            return true; // Nothing to remove
+        }
+
+        return file_put_contents($htaccessFile, $newContent) !== false;
+    }
+
+    /**
+     * Find insertion point in .htaccess content
+     *
+     * @return array{pattern: string, match: string}|null
+     */
+    private function findInsertionPoint(string $content): ?array
+    {
+        // Try Apache 2.4 style first
+        if (preg_match('/(# Apache 2\.2\s+<IfModule !mod_authz_core\.c>.*?<\/IfModule>)/s', $content, $matches)) {
+            return [
+                'pattern' => '/(# Apache 2\.2\s+<IfModule !mod_authz_core\.c>.*?<\/IfModule>)/s',
+                'match' => $matches[1]
+            ];
+        }
+
+        // Try Apache 2.2 style
+        if (preg_match('/(Deny from all)/', $content, $matches)) {
+            return [
+                'pattern' => '/(Deny from all)/',
+                'match' => $matches[1]
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Generate Apache .htaccess rules for both 2.2 and 2.4
+     */
+    private function generateHtaccessRules(): string
+    {
+        return <<<'HTACCESS'
+
+
+# Allow static assets and API endpoints for plugins
+<FilesMatch "\.(js|css|map|json|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|eot|otf)$">
+    # Apache 2.4
+    <IfModule mod_authz_core.c>
+        Require all granted
+    </IfModule>
+
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Allow from all
+    </IfModule>
+</FilesMatch>
+
+# Allow PHP API endpoints in plugin directories
+<FilesMatch "^plugins/.+\.php$">
+    # Apache 2.4
+    <IfModule mod_authz_core.c>
+        Require all granted
+    </IfModule>
+
+    # Apache 2.2
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Allow from all
+    </IfModule>
+</FilesMatch>
+HTACCESS;
+    }
+
+    /**
+     * Log message to error log
+     */
+    private function log(string $message): void
+    {
+        error_log('[Markdown-Support] ' . $message);
+    }
+}

--- a/src/Asset/AssetInjector.php
+++ b/src/Asset/AssetInjector.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkdownSupport\Asset;
+
+use MarkdownSupport\Config\ConfigCache;
+
+/**
+ * AssetInjector - Injects CSS/JS assets into osTicket pages
+ *
+ * Handles:
+ * - CSS injection (in <head> for FOUC prevention)
+ * - JavaScript injection (deferred for performance)
+ * - Configuration injection (window.osTicketMarkdownConfig)
+ * - Output buffer-based injection for pages without proper hooks
+ *
+ * @package MarkdownSupport
+ */
+final class AssetInjector
+{
+    private string $pluginUrl;
+    private ConfigCache $configCache;
+
+    public function __construct(string $pluginUrl, ConfigCache $configCache)
+    {
+        $this->pluginUrl = rtrim($pluginUrl, '/');
+        $this->configCache = $configCache;
+    }
+
+    /**
+     * Check if current page needs Markdown editor assets
+     *
+     * @return bool True if page is ticket-related
+     */
+    public function isEditorPage(): bool
+    {
+        $script = basename($_SERVER['SCRIPT_NAME'] ?? '');
+        $requestUri = $_SERVER['REQUEST_URI'] ?? '';
+
+        // Pages that need the editor
+        return in_array($script, ['tickets.php', 'ticket.php'], true)
+            || ($script === 'ajax.php' && strpos($requestUri, 'ticket') !== false);
+    }
+
+    /**
+     * Check if current request is AJAX
+     *
+     * @return bool True if AJAX request
+     */
+    public function isAjaxRequest(): bool
+    {
+        $xRequestedWith = $_SERVER['HTTP_X_REQUESTED_WITH'] ?? '';
+        return strtolower($xRequestedWith) === 'xmlhttprequest';
+    }
+
+    /**
+     * Get editor assets as HTML string
+     *
+     * @return string HTML with config, CSS, and JS tags
+     */
+    public function getAssetsHtml(): string
+    {
+        $config = $this->configCache;
+
+        $defaultFormat = $config->get('default_format', 'markdown');
+        $allowFormatSwitch = (bool) $config->get('allow_format_switch', true);
+        $showToolbar = (bool) $config->get('show_toolbar', true);
+        $version = $config->get('installed_version', '');
+
+        // Build URLs with cache-busting
+        $cacheParam = $version ? '?v=' . urlencode($version) : '';
+        $cssUrl = $this->pluginUrl . '/css/markdown-editor.css' . $cacheParam;
+        $jsUrl = $this->pluginUrl . '/js/markdown-editor.js' . $cacheParam;
+
+        // Determine preview API URL
+        $previewApiUrl = $this->getPreviewApiUrl();
+
+        // Build HTML
+        $html = $this->buildConfigScript($defaultFormat, $allowFormatSwitch, $showToolbar, $previewApiUrl);
+        $html .= $this->buildCssTag($cssUrl);
+        $html .= $this->buildJsTag($jsUrl);
+
+        return $html;
+    }
+
+    /**
+     * Inject assets directly (for use in Signal handlers)
+     */
+    public function injectAssets(): void
+    {
+        echo $this->getAssetsHtml();
+    }
+
+    /**
+     * Output buffer callback to inject assets into HTML output
+     *
+     * @param string $buffer HTML output buffer
+     * @return string Modified HTML with injected assets
+     */
+    public function injectAssetsIntoOutput(string $buffer): string
+    {
+        // Prevent double injection
+        if (strpos($buffer, 'window.osTicketMarkdownConfig') !== false) {
+            return $buffer;
+        }
+
+        $assets = $this->getAssetsHtml();
+
+        // Inject before </head> if possible
+        if (stripos($buffer, '</head>') !== false) {
+            return str_ireplace('</head>', $assets . '</head>', $buffer);
+        }
+
+        // Fallback: inject before </body>
+        if (stripos($buffer, '</body>') !== false) {
+            return str_ireplace('</body>', $assets . '</body>', $buffer);
+        }
+
+        // Last resort: append to end
+        return $buffer . $assets;
+    }
+
+    /**
+     * Build JavaScript config object
+     */
+    private function buildConfigScript(
+        string $defaultFormat,
+        bool $allowFormatSwitch,
+        bool $showToolbar,
+        string $previewApiUrl
+    ): string {
+        $config = [
+            'defaultFormat' => $defaultFormat,
+            'allowFormatSwitch' => $allowFormatSwitch,
+            'showToolbar' => $showToolbar,
+            'previewApiUrl' => $previewApiUrl,
+        ];
+
+        return '<script>' . "\n"
+            . 'window.osTicketMarkdownConfig = ' . json_encode($config, JSON_UNESCAPED_SLASHES) . ';' . "\n"
+            . '</script>' . "\n";
+    }
+
+    /**
+     * Build CSS link tag
+     */
+    private function buildCssTag(string $url): string
+    {
+        return '<link rel="stylesheet" href="' . htmlspecialchars($url, ENT_QUOTES, 'UTF-8') . '">' . "\n";
+    }
+
+    /**
+     * Build deferred JavaScript tag
+     */
+    private function buildJsTag(string $url): string
+    {
+        return '<script defer src="' . htmlspecialchars($url, ENT_QUOTES, 'UTF-8') . '"></script>' . "\n";
+    }
+
+    /**
+     * Get preview API URL
+     *
+     * Returns path relative to osTicket root.
+     */
+    private function getPreviewApiUrl(): string
+    {
+        // ROOT_PATH is osTicket's web root path
+        if (defined('ROOT_PATH')) {
+            return ROOT_PATH . 'api/markdown-preview.php';
+        }
+
+        // Fallback for testing
+        return '/api/markdown-preview.php';
+    }
+}

--- a/src/Config/ConfigCache.php
+++ b/src/Config/ConfigCache.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkdownSupport\Config;
+
+/**
+ * ConfigCache - Thread-safe singleton for plugin configuration
+ *
+ * Solves the osTicket Signal callback problem where new plugin instances
+ * are created without proper configuration context.
+ *
+ * Usage:
+ *   // In bootstrap()
+ *   ConfigCache::getInstance()->populate($config);
+ *
+ *   // In Signal callbacks
+ *   $value = ConfigCache::getInstance()->get('key', 'default');
+ *
+ * @package MarkdownSupport
+ */
+final class ConfigCache
+{
+    private static ?self $instance = null;
+
+    /** @var array<string, mixed> */
+    private array $config = [];
+
+    private bool $populated = false;
+
+    /**
+     * Private constructor to prevent direct instantiation
+     */
+    private function __construct()
+    {
+    }
+
+    /**
+     * Prevent cloning of the singleton instance
+     */
+    private function __clone()
+    {
+    }
+
+    /**
+     * Get singleton instance
+     */
+    public static function getInstance(): self
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Populate cache with configuration values
+     *
+     * Should be called once in bootstrap() with the real config values.
+     *
+     * @param array<string, mixed> $config Configuration key-value pairs
+     */
+    public function populate(array $config): void
+    {
+        $this->config = $config;
+        $this->populated = true;
+    }
+
+    /**
+     * Get configuration value
+     *
+     * @param string $key Configuration key
+     * @param mixed $default Default value if key not found
+     * @return mixed
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        return $this->config[$key] ?? $default;
+    }
+
+    /**
+     * Set single configuration value
+     *
+     * @param string $key Configuration key
+     * @param mixed $value Configuration value
+     */
+    public function set(string $key, mixed $value): void
+    {
+        $this->config[$key] = $value;
+    }
+
+    /**
+     * Check if cache has been populated
+     */
+    public function isPopulated(): bool
+    {
+        return $this->populated;
+    }
+
+    /**
+     * Get all cached configuration
+     *
+     * @return array<string, mixed>
+     */
+    public function all(): array
+    {
+        return $this->config;
+    }
+
+    /**
+     * Clear all cached configuration
+     *
+     * Useful for testing.
+     */
+    public function clear(): void
+    {
+        $this->config = [];
+        $this->populated = false;
+    }
+
+    /**
+     * Reset singleton instance
+     *
+     * WARNING: Only use in tests!
+     */
+    public static function resetInstance(): void
+    {
+        self::$instance = null;
+    }
+}

--- a/src/Core/CorePatcher.php
+++ b/src/Core/CorePatcher.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkdownSupport\Core;
+
+/**
+ * CorePatcher - Handles osTicket core file patching
+ *
+ * Responsible for:
+ * - Extending ThreadEntryBody::$types via Reflection
+ * - Patching class.thread.php for fromFormattedText() support
+ * - Managing backup/restore of patched files
+ *
+ * WARNING: Core file patching is fragile and may break on osTicket updates.
+ * Always create backups and verify patches after updates.
+ *
+ * @package MarkdownSupport
+ */
+final class CorePatcher
+{
+    private const BACKUP_SUFFIX = '.markdown-backup';
+
+    private string $includeDir;
+
+    public function __construct(string $includeDir)
+    {
+        $this->includeDir = rtrim($includeDir, '/');
+    }
+
+    /**
+     * Extend ThreadEntryBody::$types array using Reflection
+     *
+     * This is the CORE technique that allows us to add 'markdown' as a valid
+     * ThreadEntryBody type WITHOUT modifying core files.
+     *
+     * @return bool True if successful
+     */
+    public function extendThreadEntryTypes(): bool
+    {
+        if (!class_exists('ThreadEntryBody')) {
+            $this->log('Warning: ThreadEntryBody class not found');
+            return false;
+        }
+
+        try {
+            $reflection = new \ReflectionClass('ThreadEntryBody');
+            $typesProperty = $reflection->getProperty('types');
+            $typesProperty->setAccessible(true);
+
+            $types = $typesProperty->getValue();
+
+            if (!in_array('markdown', $types, true)) {
+                $types[] = 'markdown';
+                $typesProperty->setValue(null, $types);
+            }
+
+            return true;
+        } catch (\ReflectionException $e) {
+            $this->log('Failed to extend ThreadEntryBody::$types: ' . $e->getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Patch ThreadEntryBody::fromFormattedText() to support 'markdown' format
+     *
+     * This adds a case statement to handle 'markdown' format in the factory method.
+     *
+     * @return bool True if patch applied or already exists
+     */
+    public function patchFromFormattedText(): bool
+    {
+        $threadFile = $this->includeDir . '/class.thread.php';
+
+        if (!file_exists($threadFile)) {
+            $this->log('Error: class.thread.php not found');
+            return false;
+        }
+
+        $content = file_get_contents($threadFile);
+        if ($content === false) {
+            $this->log('Error: Cannot read class.thread.php');
+            return false;
+        }
+
+        // Check if already patched
+        if (strpos($content, "case 'markdown':") !== false) {
+            return true;
+        }
+
+        // Create backup
+        if (!$this->createBackup($threadFile)) {
+            return false;
+        }
+
+        // Apply patch
+        $patchedContent = $this->applyPatch($content);
+        if ($patchedContent === $content) {
+            $this->log('Error: Unable to apply patch - pattern not found');
+            return false;
+        }
+
+        // Write patched file
+        if (file_put_contents($threadFile, $patchedContent) === false) {
+            $this->log('Error: Failed to write patched file');
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Restore original class.thread.php from backup
+     *
+     * @return bool True if restoration successful
+     */
+    public function restoreFromBackup(): bool
+    {
+        $threadFile = $this->includeDir . '/class.thread.php';
+        $backupFile = $threadFile . self::BACKUP_SUFFIX;
+
+        if (!file_exists($backupFile)) {
+            return true; // No backup exists, nothing to restore
+        }
+
+        if (!copy($backupFile, $threadFile)) {
+            $this->log('Error: Failed to restore from backup');
+            return false;
+        }
+
+        unlink($backupFile);
+        return true;
+    }
+
+    /**
+     * Check if patch is currently applied
+     *
+     * @return bool True if patch is applied
+     */
+    public function isPatchApplied(): bool
+    {
+        $threadFile = $this->includeDir . '/class.thread.php';
+
+        if (!file_exists($threadFile)) {
+            return false;
+        }
+
+        $content = file_get_contents($threadFile);
+        return $content !== false && strpos($content, "case 'markdown':") !== false;
+    }
+
+    /**
+     * Verify patch integrity after osTicket update
+     *
+     * Compares file hash with backup to detect if core was updated.
+     *
+     * @return bool True if patch is intact, false if reapplication needed
+     */
+    public function verifyPatchIntegrity(): bool
+    {
+        $threadFile = $this->includeDir . '/class.thread.php';
+        $backupFile = $threadFile . self::BACKUP_SUFFIX;
+
+        if (!file_exists($backupFile)) {
+            return false; // No backup, can't verify
+        }
+
+        // Check if patch is still present
+        return $this->isPatchApplied();
+    }
+
+    /**
+     * Create backup of original file
+     */
+    private function createBackup(string $file): bool
+    {
+        $backupFile = $file . self::BACKUP_SUFFIX;
+
+        if (file_exists($backupFile)) {
+            return true; // Backup already exists
+        }
+
+        if (!copy($file, $backupFile)) {
+            $this->log('Error: Failed to create backup');
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Apply the markdown case patch to content
+     */
+    private function applyPatch(string $content): string
+    {
+        // Try standard formatting first
+        $patterns = [
+            // Standard indentation (8 spaces)
+            [
+                'search' => "case 'html':\n            return new HtmlThreadEntryBody(\$text, array('strip-embedded'=>false) + \$options);",
+                'replace' => "case 'html':\n            return new HtmlThreadEntryBody(\$text, array('strip-embedded'=>false) + \$options);\n        case 'markdown':\n            return new MarkdownThreadEntryBody(\$text, \$options);"
+            ],
+            // Alternative indentation (12 spaces)
+            [
+                'search' => "case 'html':\n                return new HtmlThreadEntryBody(\$text, array('strip-embedded'=>false) + \$options);",
+                'replace' => "case 'html':\n                return new HtmlThreadEntryBody(\$text, array('strip-embedded'=>false) + \$options);\n            case 'markdown':\n                return new MarkdownThreadEntryBody(\$text, \$options);"
+            ]
+        ];
+
+        foreach ($patterns as $pattern) {
+            $patched = str_replace($pattern['search'], $pattern['replace'], $content);
+            if ($patched !== $content) {
+                return $patched;
+            }
+        }
+
+        return $content; // No pattern matched
+    }
+
+    /**
+     * Log message to error log
+     */
+    private function log(string $message): void
+    {
+        error_log('[Markdown-Support] ' . $message);
+    }
+}

--- a/src/Format/FormatHandlerInterface.php
+++ b/src/Format/FormatHandlerInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkdownSupport\Format;
+
+/**
+ * Interface for format determination
+ *
+ * Implementations determine the correct format (markdown/html/text)
+ * for ticket creation based on user selection, auto-detection, or config.
+ *
+ * @package MarkdownSupport
+ */
+interface FormatHandlerInterface
+{
+    public const FORMAT_MARKDOWN = 'markdown';
+    public const FORMAT_HTML = 'html';
+    public const FORMAT_TEXT = 'text';
+
+    /**
+     * Determine format based on input data and configuration
+     *
+     * Priority:
+     * 1. Explicit user selection (format field)
+     * 2. Auto-detection (if enabled)
+     * 3. Default format from config
+     *
+     * @param array{format?: string, message?: string} $data Input data
+     * @return string One of: 'markdown', 'html', 'text'
+     */
+    public function determineFormat(array $data): string;
+
+    /**
+     * Validate and sanitize format value
+     *
+     * @param string $format Format to validate
+     * @return string Valid format (falls back to 'html' if invalid)
+     */
+    public function validateFormat(string $format): string;
+}

--- a/src/Format/MarkdownDetectorInterface.php
+++ b/src/Format/MarkdownDetectorInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkdownSupport\Format;
+
+/**
+ * Interface for Markdown syntax detection
+ *
+ * Implementations analyze text to determine if it contains Markdown syntax.
+ * Used for auto-detection feature when creating tickets via API.
+ *
+ * @package MarkdownSupport
+ */
+interface MarkdownDetectorInterface
+{
+    /**
+     * Check if text contains Markdown syntax
+     *
+     * @param string $text Text to analyze
+     * @param int $threshold Minimum confidence score (0-100) to return true
+     * @return bool True if Markdown syntax detected with confidence >= threshold
+     */
+    public function hasMarkdownSyntax(string $text, int $threshold = 5): bool;
+
+    /**
+     * Calculate confidence score (0-100) that text is Markdown
+     *
+     * Higher score = more confident that text contains Markdown syntax.
+     *
+     * @param string $text Text to analyze
+     * @return int Confidence score (0-100)
+     */
+    public function getConfidenceScore(string $text): int;
+
+    /**
+     * Get detailed analysis of Markdown features found
+     *
+     * @param string $text Text to analyze
+     * @return array<string, array{count: int, weight: int, matches: string[]}> Features found
+     */
+    public function analyzeFeatures(string $text): array;
+}

--- a/src/Format/MarkdownSanitizer.php
+++ b/src/Format/MarkdownSanitizer.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkdownSupport\Format;
+
+/**
+ * MarkdownSanitizer - Unified XSS prevention for Markdown content
+ *
+ * Provides a single, consistent sanitization layer for all Markdown rendering:
+ * - Backend (thread entries)
+ * - API (preview endpoint)
+ * - Export (email/PDF)
+ *
+ * Security Architecture:
+ * Layer 1: Parsedown SafeMode (escapes inline HTML, blocks <script>)
+ * Layer 2: This sanitizer (removes javascript: URLs, on* attributes)
+ *
+ * @package MarkdownSupport
+ */
+final class MarkdownSanitizer
+{
+    /**
+     * Sanitize HTML to prevent XSS attacks
+     *
+     * Should be called AFTER Parsedown rendering but BEFORE output.
+     *
+     * @param string $html HTML to sanitize
+     * @return string Sanitized HTML
+     */
+    public static function sanitize(string $html): string
+    {
+        if ($html === '') {
+            return '';
+        }
+
+        // Remove javascript: URLs (including URL-encoded variants)
+        $html = self::removeJavaScriptUrls($html);
+
+        // Remove data: URLs (potential XSS vector)
+        $html = self::removeDataUrls($html);
+
+        // Remove on* event handlers (onclick, onload, onerror, etc.)
+        $html = self::removeEventHandlers($html);
+
+        // Remove IE-specific expression() CSS (XSS vector)
+        $html = self::removeExpressionCss($html);
+
+        // Remove any remaining script tags (defense in depth)
+        $html = self::removeScriptTags($html);
+
+        return $html;
+    }
+
+    /**
+     * Remove javascript: URLs from href/src attributes
+     */
+    private static function removeJavaScriptUrls(string $html): string
+    {
+        return preg_replace(
+            '/(<[^>]+\s)(href|src)\s*=\s*["\']?\s*javascript:/i',
+            '$1data-blocked-$2="',
+            $html
+        ) ?? $html;
+    }
+
+    /**
+     * Remove data: URLs (potential XSS via data:text/html)
+     */
+    private static function removeDataUrls(string $html): string
+    {
+        return preg_replace(
+            '/(<[^>]+\s)(href|src)\s*=\s*["\']?\s*data:/i',
+            '$1data-blocked-$2="',
+            $html
+        ) ?? $html;
+    }
+
+    /**
+     * Remove on* event handler attributes
+     *
+     * Runs multiple passes to catch all attributes in same tag.
+     */
+    private static function removeEventHandlers(string $html): string
+    {
+        $maxIterations = 10; // Prevent infinite loop
+        $iteration = 0;
+
+        do {
+            $before = $html;
+            // Remove quoted event handlers: onclick="..."
+            $html = preg_replace(
+                '/(<[^>]+\s)on\w+\s*=\s*["\'][^"\']*["\']/i',
+                '$1',
+                $html
+            ) ?? $html;
+            // Remove unquoted event handlers: onclick=alert(1)
+            $html = preg_replace(
+                '/(<[^>]+\s)on\w+\s*=\s*[^\s>]+/i',
+                '$1',
+                $html
+            ) ?? $html;
+            $iteration++;
+        } while ($before !== $html && $iteration < $maxIterations);
+
+        return $html;
+    }
+
+    /**
+     * Remove style attributes containing expression() (IE-specific XSS)
+     */
+    private static function removeExpressionCss(string $html): string
+    {
+        return preg_replace(
+            '/(<[^>]+\s)style\s*=\s*["\'][^"\']*expression\s*\([^"\']*["\']/i',
+            '$1',
+            $html
+        ) ?? $html;
+    }
+
+    /**
+     * Remove any remaining <script> tags (defense in depth)
+     *
+     * Parsedown SafeMode should already handle this, but we double-check.
+     */
+    private static function removeScriptTags(string $html): string
+    {
+        return preg_replace(
+            '/<script[^>]*>.*?<\/script>/is',
+            '',
+            $html
+        ) ?? $html;
+    }
+
+    /**
+     * Sanitize using osTicket's Format class if available
+     *
+     * This delegates to osTicket's htmLawed-based sanitizer for
+     * comprehensive sanitization. Use this when running inside osTicket.
+     *
+     * @param string $html HTML to sanitize
+     * @return string Sanitized HTML
+     */
+    public static function sanitizeWithOsTicket(string $html): string
+    {
+        // First apply our sanitization
+        $html = self::sanitize($html);
+
+        // Then delegate to osTicket's Format::sanitize() if available
+        if (class_exists('Format') && method_exists('Format', 'sanitize')) {
+            return \Format::sanitize($html);
+        }
+
+        return $html;
+    }
+}

--- a/src/Signal/ThreadEntryHandler.php
+++ b/src/Signal/ThreadEntryHandler.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkdownSupport\Signal;
+
+use MarkdownSupport\Config\ConfigCache;
+
+/**
+ * ThreadEntryHandler - Handles thread entry creation signals
+ *
+ * Responsible for:
+ * - Format detection and correction
+ * - Newline restoration (osTicket strips them during save)
+ * - Auto-conversion to Markdown (when enabled)
+ *
+ * @package MarkdownSupport
+ */
+final class ThreadEntryHandler
+{
+    private ConfigCache $configCache;
+    /** @var object|null Markdown detector with hasMarkdownSyntax() method */
+    private ?object $detector;
+
+    /**
+     * @param ConfigCache $configCache
+     * @param object|null $detector Object with hasMarkdownSyntax($text, $threshold) method
+     */
+    public function __construct(ConfigCache $configCache, ?object $detector = null)
+    {
+        $this->configCache = $configCache;
+        $this->detector = $detector;
+    }
+
+    /**
+     * Handle threadentry.created signal
+     *
+     * @param object $entry ThreadEntry object
+     */
+    public function onThreadEntryCreated(object $entry): void
+    {
+        // Restore newlines if they were stripped
+        $this->restoreNewlines($entry);
+
+        // Detect and set format
+        $format = $this->detectFormat();
+
+        if ($format !== null) {
+            $this->updateEntryFormat($entry, $format);
+        }
+
+        // Auto-convert to Markdown if enabled
+        if ($this->shouldAutoConvert($entry)) {
+            $this->autoConvertToMarkdown($entry);
+        }
+    }
+
+    /**
+     * Restore newlines that get stripped during osTicket's save process
+     */
+    private function restoreNewlines(object $entry): void
+    {
+        $body = $this->getEntryBody($entry);
+        $postBody = $this->getPostBody();
+
+        if ($postBody === null) {
+            return;
+        }
+
+        // If newlines are in POST but not in saved entry, restore them
+        if (strpos($postBody, "\n") !== false && strpos($body, "\n") === false) {
+            $this->updateEntryBody($entry, $postBody);
+        }
+    }
+
+    /**
+     * Detect format from request data
+     *
+     * @return string|null Format if detected, null otherwise
+     */
+    private function detectFormat(): ?string
+    {
+        // Check POST data first
+        if (isset($_POST['format']) && $_POST['format'] !== '') {
+            return $this->validateFormat($_POST['format']);
+        }
+
+        // Check JSON body for API requests
+        $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
+        if (strpos($contentType, 'application/json') !== false) {
+            $jsonInput = file_get_contents('php://input');
+            if ($jsonInput !== false) {
+                $data = json_decode($jsonInput, true);
+                if (isset($data['format']) && $data['format'] !== '') {
+                    return $this->validateFormat($data['format']);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if auto-conversion should be applied
+     */
+    private function shouldAutoConvert(object $entry): bool
+    {
+        // Only if enabled in config
+        if (!$this->configCache->get('auto_convert_to_markdown', false)) {
+            return false;
+        }
+
+        // Only if format was not explicitly set
+        if (isset($_POST['format']) && $_POST['format'] !== '') {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Auto-convert entry to Markdown if content contains Markdown syntax
+     */
+    private function autoConvertToMarkdown(object $entry): void
+    {
+        if ($this->detector === null) {
+            return;
+        }
+
+        $postBody = $this->getPostBody();
+        if ($postBody === null) {
+            return;
+        }
+
+        $threshold = (int) $this->configCache->get('auto_detect_threshold', 5);
+
+        if ($this->detector->hasMarkdownSyntax($postBody, $threshold)) {
+            $this->updateEntryFormat($entry, 'markdown');
+        }
+    }
+
+    /**
+     * Get body content from POST data
+     */
+    private function getPostBody(): ?string
+    {
+        $fields = ['response', 'note', 'message', 'body'];
+
+        foreach ($fields as $field) {
+            if (isset($_POST[$field]) && $_POST[$field] !== '') {
+                return $_POST[$field];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Get entry body via reflection or method call
+     */
+    private function getEntryBody(object $entry): string
+    {
+        if (method_exists($entry, 'getBody')) {
+            return (string) $entry->getBody();
+        }
+
+        return '';
+    }
+
+    /**
+     * Update entry body in database
+     */
+    private function updateEntryBody(object $entry, string $body): void
+    {
+        if (!defined('THREAD_ENTRY_TABLE') || !function_exists('db_input') || !function_exists('db_query')) {
+            return;
+        }
+
+        $entryId = $this->getEntryId($entry);
+        if ($entryId === null) {
+            return;
+        }
+
+        $sql = 'UPDATE ' . THREAD_ENTRY_TABLE
+            . ' SET body = ' . db_input($body)
+            . ' WHERE id = ' . db_input($entryId);
+
+        db_query($sql);
+    }
+
+    /**
+     * Update entry format in database
+     */
+    private function updateEntryFormat(object $entry, string $format): void
+    {
+        if (!defined('THREAD_ENTRY_TABLE') || !function_exists('db_input') || !function_exists('db_query')) {
+            return;
+        }
+
+        $entryId = $this->getEntryId($entry);
+        if ($entryId === null) {
+            return;
+        }
+
+        // Check current format
+        $currentFormat = $this->getEntryFormat($entry);
+        if ($currentFormat === $format) {
+            return;
+        }
+
+        $sql = 'UPDATE ' . THREAD_ENTRY_TABLE
+            . ' SET format = ' . db_input($format)
+            . ' WHERE id = ' . db_input($entryId);
+
+        if (!db_query($sql)) {
+            error_log('[Markdown-Support] Failed to update format: ' . (function_exists('db_error') ? db_error() : 'unknown'));
+        }
+    }
+
+    /**
+     * Get entry ID
+     */
+    private function getEntryId(object $entry): ?int
+    {
+        if (method_exists($entry, 'getId')) {
+            return (int) $entry->getId();
+        }
+
+        return null;
+    }
+
+    /**
+     * Get entry format
+     */
+    private function getEntryFormat(object $entry): string
+    {
+        if (method_exists($entry, 'get')) {
+            return (string) $entry->get('format');
+        }
+
+        return '';
+    }
+
+    /**
+     * Validate format value
+     */
+    private function validateFormat(string $format): string
+    {
+        $format = strtolower(trim($format));
+        $validFormats = ['markdown', 'html', 'text'];
+
+        return in_array($format, $validFormats, true) ? $format : 'html';
+    }
+}

--- a/tests/Unit/Asset/AssetInjectorTest.php
+++ b/tests/Unit/Asset/AssetInjectorTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkdownSupport\Tests\Unit\Asset;
+
+use MarkdownSupport\Asset\AssetInjector;
+use MarkdownSupport\Config\ConfigCache;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MarkdownSupport\Asset\AssetInjector
+ */
+final class AssetInjectorTest extends TestCase
+{
+    private ConfigCache $configCache;
+
+    protected function setUp(): void
+    {
+        ConfigCache::resetInstance();
+        $this->configCache = ConfigCache::getInstance();
+        $this->configCache->populate([
+            'default_format' => 'markdown',
+            'allow_format_switch' => true,
+            'show_toolbar' => true,
+            'installed_version' => '1.0.0',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        ConfigCache::resetInstance();
+    }
+
+    /** @test */
+    public function it_generates_config_script(): void
+    {
+        $injector = new AssetInjector('/plugins/markdown-support', $this->configCache);
+        $html = $injector->getAssetsHtml();
+
+        $this->assertStringContainsString('window.osTicketMarkdownConfig', $html);
+        $this->assertStringContainsString('"defaultFormat":"markdown"', $html);
+        $this->assertStringContainsString('"allowFormatSwitch":true', $html);
+        $this->assertStringContainsString('"showToolbar":true', $html);
+    }
+
+    /** @test */
+    public function it_includes_css_tag_with_cache_busting(): void
+    {
+        $injector = new AssetInjector('/plugins/markdown-support', $this->configCache);
+        $html = $injector->getAssetsHtml();
+
+        $this->assertStringContainsString('<link rel="stylesheet"', $html);
+        $this->assertStringContainsString('markdown-editor.css?v=1.0.0', $html);
+    }
+
+    /** @test */
+    public function it_includes_deferred_js_tag(): void
+    {
+        $injector = new AssetInjector('/plugins/markdown-support', $this->configCache);
+        $html = $injector->getAssetsHtml();
+
+        $this->assertStringContainsString('<script defer src=', $html);
+        $this->assertStringContainsString('markdown-editor.js?v=1.0.0', $html);
+    }
+
+    /** @test */
+    public function it_escapes_urls_properly(): void
+    {
+        $this->configCache->set('installed_version', '1.0.0&test=<script>');
+
+        $injector = new AssetInjector('/plugins/markdown-support', $this->configCache);
+        $html = $injector->getAssetsHtml();
+
+        // URL encoding converts <script> to %3Cscript%3E
+        $this->assertStringNotContainsString('><script>', $html);
+        $this->assertStringContainsString('%3Cscript%3E', $html);
+    }
+
+    /** @test */
+    public function it_injects_assets_before_head_closing_tag(): void
+    {
+        $injector = new AssetInjector('/plugins/markdown-support', $this->configCache);
+        $buffer = '<html><head><title>Test</title></head><body></body></html>';
+
+        $result = $injector->injectAssetsIntoOutput($buffer);
+
+        $this->assertStringContainsString('osTicketMarkdownConfig', $result);
+        // Assets should be before </head>
+        $headEndPos = strpos($result, '</head>');
+        $configPos = strpos($result, 'osTicketMarkdownConfig');
+        $this->assertLessThan($headEndPos, $configPos);
+    }
+
+    /** @test */
+    public function it_injects_assets_before_body_closing_tag_as_fallback(): void
+    {
+        $injector = new AssetInjector('/plugins/markdown-support', $this->configCache);
+        $buffer = '<html><body><p>Content</p></body></html>';
+
+        $result = $injector->injectAssetsIntoOutput($buffer);
+
+        $this->assertStringContainsString('osTicketMarkdownConfig', $result);
+        // Assets should be before </body>
+        $bodyEndPos = strpos($result, '</body>');
+        $configPos = strpos($result, 'osTicketMarkdownConfig');
+        $this->assertLessThan($bodyEndPos, $configPos);
+    }
+
+    /** @test */
+    public function it_prevents_double_injection(): void
+    {
+        $injector = new AssetInjector('/plugins/markdown-support', $this->configCache);
+        $buffer = '<html><head>window.osTicketMarkdownConfig = {};</head></html>';
+
+        $result = $injector->injectAssetsIntoOutput($buffer);
+
+        // Should return unchanged (already injected)
+        $this->assertSame($buffer, $result);
+    }
+
+    /** @test */
+    public function it_appends_assets_when_no_closing_tags_found(): void
+    {
+        $injector = new AssetInjector('/plugins/markdown-support', $this->configCache);
+        $buffer = '<div>Incomplete HTML';
+
+        $result = $injector->injectAssetsIntoOutput($buffer);
+
+        $this->assertStringStartsWith($buffer, $result);
+        $this->assertStringContainsString('osTicketMarkdownConfig', $result);
+    }
+
+    /** @test */
+    public function it_uses_default_values_when_config_missing(): void
+    {
+        $this->configCache->clear();
+        $injector = new AssetInjector('/plugins/markdown-support', $this->configCache);
+
+        $html = $injector->getAssetsHtml();
+
+        $this->assertStringContainsString('"defaultFormat":"markdown"', $html);
+        $this->assertStringContainsString('markdown-editor.css', $html);
+        // No version parameter when version is empty
+        $this->assertStringNotContainsString('?v=', $html);
+    }
+}

--- a/tests/Unit/Config/ConfigCacheTest.php
+++ b/tests/Unit/Config/ConfigCacheTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkdownSupport\Tests\Unit\Config;
+
+use MarkdownSupport\Config\ConfigCache;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MarkdownSupport\Config\ConfigCache
+ */
+final class ConfigCacheTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // Reset singleton between tests
+        ConfigCache::resetInstance();
+    }
+
+    protected function tearDown(): void
+    {
+        ConfigCache::resetInstance();
+    }
+
+    /** @test */
+    public function it_returns_same_instance(): void
+    {
+        $instance1 = ConfigCache::getInstance();
+        $instance2 = ConfigCache::getInstance();
+
+        $this->assertSame($instance1, $instance2);
+    }
+
+    /** @test */
+    public function it_populates_config_values(): void
+    {
+        $cache = ConfigCache::getInstance();
+        $cache->populate([
+            'key1' => 'value1',
+            'key2' => true,
+            'key3' => 42,
+        ]);
+
+        $this->assertTrue($cache->isPopulated());
+        $this->assertSame('value1', $cache->get('key1'));
+        $this->assertTrue($cache->get('key2'));
+        $this->assertSame(42, $cache->get('key3'));
+    }
+
+    /** @test */
+    public function it_returns_default_for_missing_keys(): void
+    {
+        $cache = ConfigCache::getInstance();
+
+        $this->assertNull($cache->get('nonexistent'));
+        $this->assertSame('default', $cache->get('nonexistent', 'default'));
+        $this->assertSame(123, $cache->get('nonexistent', 123));
+    }
+
+    /** @test */
+    public function it_sets_individual_values(): void
+    {
+        $cache = ConfigCache::getInstance();
+
+        $cache->set('single_key', 'single_value');
+
+        $this->assertSame('single_value', $cache->get('single_key'));
+    }
+
+    /** @test */
+    public function it_overwrites_existing_values(): void
+    {
+        $cache = ConfigCache::getInstance();
+        $cache->populate(['key' => 'original']);
+
+        $cache->set('key', 'updated');
+
+        $this->assertSame('updated', $cache->get('key'));
+    }
+
+    /** @test */
+    public function it_returns_all_config_values(): void
+    {
+        $cache = ConfigCache::getInstance();
+        $config = [
+            'a' => 1,
+            'b' => 2,
+            'c' => 3,
+        ];
+        $cache->populate($config);
+
+        $this->assertSame($config, $cache->all());
+    }
+
+    /** @test */
+    public function it_clears_all_values(): void
+    {
+        $cache = ConfigCache::getInstance();
+        $cache->populate(['key' => 'value']);
+
+        $cache->clear();
+
+        $this->assertFalse($cache->isPopulated());
+        $this->assertNull($cache->get('key'));
+        $this->assertEmpty($cache->all());
+    }
+
+    /** @test */
+    public function it_is_not_populated_initially(): void
+    {
+        $cache = ConfigCache::getInstance();
+
+        $this->assertFalse($cache->isPopulated());
+    }
+
+    /** @test */
+    public function reset_instance_creates_new_singleton(): void
+    {
+        $instance1 = ConfigCache::getInstance();
+        $instance1->set('marker', 'original');
+
+        ConfigCache::resetInstance();
+
+        $instance2 = ConfigCache::getInstance();
+
+        $this->assertNotSame($instance1, $instance2);
+        $this->assertNull($instance2->get('marker'));
+    }
+}

--- a/tests/Unit/Format/MarkdownSanitizerTest.php
+++ b/tests/Unit/Format/MarkdownSanitizerTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MarkdownSupport\Tests\Unit\Format;
+
+use MarkdownSupport\Format\MarkdownSanitizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \MarkdownSupport\Format\MarkdownSanitizer
+ */
+final class MarkdownSanitizerTest extends TestCase
+{
+    /** @test */
+    public function it_returns_empty_string_for_empty_input(): void
+    {
+        $this->assertSame('', MarkdownSanitizer::sanitize(''));
+    }
+
+    /** @test */
+    public function it_does_not_modify_safe_html(): void
+    {
+        $safeHtml = '<p>Hello <strong>World</strong>!</p>';
+
+        $this->assertSame($safeHtml, MarkdownSanitizer::sanitize($safeHtml));
+    }
+
+    /** @test */
+    public function it_blocks_javascript_urls_in_href(): void
+    {
+        $malicious = '<a href="javascript:alert(1)">Click</a>';
+        $sanitized = MarkdownSanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('javascript:', $sanitized);
+        $this->assertStringContainsString('data-blocked-href', $sanitized);
+    }
+
+    /** @test */
+    public function it_blocks_javascript_urls_in_src(): void
+    {
+        $malicious = '<img src="javascript:alert(1)">';
+        $sanitized = MarkdownSanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('javascript:', $sanitized);
+        $this->assertStringContainsString('data-blocked-src', $sanitized);
+    }
+
+    /** @test */
+    public function it_blocks_data_urls(): void
+    {
+        $malicious = '<a href="data:text/html,<script>alert(1)</script>">Click</a>';
+        $sanitized = MarkdownSanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('data:', $sanitized);
+        $this->assertStringContainsString('data-blocked-href', $sanitized);
+    }
+
+    /** @test */
+    public function it_removes_onclick_handlers(): void
+    {
+        $malicious = '<button onclick="alert(1)">Click</button>';
+        $sanitized = MarkdownSanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('onclick', $sanitized);
+    }
+
+    /** @test */
+    public function it_removes_onerror_handlers(): void
+    {
+        $malicious = '<img src="x" onerror="alert(1)">';
+        $sanitized = MarkdownSanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('onerror', $sanitized);
+    }
+
+    /** @test */
+    public function it_removes_onload_handlers(): void
+    {
+        $malicious = '<body onload="alert(1)">';
+        $sanitized = MarkdownSanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('onload', $sanitized);
+    }
+
+    /** @test */
+    public function it_removes_multiple_event_handlers_in_same_tag(): void
+    {
+        $malicious = '<div onclick="a()" onmouseover="b()" onload="c()">Test</div>';
+        $sanitized = MarkdownSanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('onclick', $sanitized);
+        $this->assertStringNotContainsString('onmouseover', $sanitized);
+        $this->assertStringNotContainsString('onload', $sanitized);
+    }
+
+    /** @test */
+    public function it_removes_expression_css(): void
+    {
+        $malicious = '<div style="background: expression(alert(1))">Test</div>';
+        $sanitized = MarkdownSanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('expression', $sanitized);
+    }
+
+    /** @test */
+    public function it_removes_script_tags(): void
+    {
+        $malicious = '<script>alert(1)</script>';
+        $sanitized = MarkdownSanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('<script', $sanitized);
+        $this->assertStringNotContainsString('alert', $sanitized);
+    }
+
+    /** @test */
+    public function it_handles_case_insensitive_javascript(): void
+    {
+        $variants = [
+            '<a href="JAVASCRIPT:alert(1)">1</a>',
+            '<a href="JavaScript:alert(1)">2</a>',
+            '<a href="JaVaScRiPt:alert(1)">3</a>',
+        ];
+
+        foreach ($variants as $malicious) {
+            $sanitized = MarkdownSanitizer::sanitize($malicious);
+            $this->assertStringNotContainsStringIgnoringCase('javascript:', $sanitized);
+        }
+    }
+
+    /** @test */
+    public function it_handles_case_insensitive_event_handlers(): void
+    {
+        $variants = [
+            '<div ONCLICK="alert(1)">1</div>',
+            '<div OnClick="alert(1)">2</div>',
+            '<div oNcLiCk="alert(1)">3</div>',
+        ];
+
+        foreach ($variants as $malicious) {
+            $sanitized = MarkdownSanitizer::sanitize($malicious);
+            $this->assertStringNotContainsStringIgnoringCase('onclick', $sanitized);
+        }
+    }
+
+    /** @test */
+    public function it_preserves_valid_styles(): void
+    {
+        $validHtml = '<div style="color: red; font-size: 14px;">Test</div>';
+        $sanitized = MarkdownSanitizer::sanitize($validHtml);
+
+        $this->assertStringContainsString('style=', $sanitized);
+        $this->assertStringContainsString('color: red', $sanitized);
+    }
+
+    /** @test */
+    public function it_preserves_valid_links(): void
+    {
+        $validHtml = '<a href="https://example.com">Link</a>';
+        $sanitized = MarkdownSanitizer::sanitize($validHtml);
+
+        $this->assertSame($validHtml, $sanitized);
+    }
+
+    /** @test */
+    public function it_preserves_valid_images(): void
+    {
+        $validHtml = '<img src="https://example.com/image.png" alt="Image">';
+        $sanitized = MarkdownSanitizer::sanitize($validHtml);
+
+        $this->assertSame($validHtml, $sanitized);
+    }
+
+    /** @test */
+    public function it_handles_unquoted_event_handlers(): void
+    {
+        $malicious = '<div onclick=alert(1)>Test</div>';
+        $sanitized = MarkdownSanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('onclick', $sanitized);
+        $this->assertStringNotContainsString('alert', $sanitized);
+    }
+
+    /** @test */
+    public function it_handles_complex_xss_payload(): void
+    {
+        $malicious = '<img src=x onerror="javascript:alert(1)" onclick="eval(atob(\'YWxlcnQoMSk=\'))"/>';
+        $sanitized = MarkdownSanitizer::sanitize($malicious);
+
+        $this->assertStringNotContainsString('onerror', $sanitized);
+        $this->assertStringNotContainsString('onclick', $sanitized);
+        $this->assertStringNotContainsString('javascript:', $sanitized);
+    }
+}


### PR DESCRIPTION
## Summary

Major refactoring of the osTicket Markdown Support Plugin following SOLID principles and modern PHP 8.x best practices.

- **Reduced main plugin class from 774 to 397 lines (50% reduction)**
- **Extracted 6 dedicated service classes** with single responsibilities
- **Added 41 new unit tests** with comprehensive XSS prevention testing
- **Security Rating: 8.5/10** (reviewed by security-coder and code-reviewer agents)

## Changes

### New Service Classes (src/)

| Class | Responsibility |
|-------|----------------|
| `ConfigCache` | Singleton for config caching (solves osTicket Signal callback issue) |
| `CorePatcher` | Core file patching via Reflection |
| `AssetInjector` | CSS/JS injection into pages |
| `AssetDeployer` | API file and .htaccess management |
| `ThreadEntryHandler` | Signal handlers for thread entries |
| `MarkdownSanitizer` | Unified XSS prevention |

### Architecture Improvements

- **Dependency Injection** pattern for better testability
- **Defense-in-Depth** XSS prevention (3 layers)
- **PSR-4 autoloading** for new service classes
- **Backward compatible** - deprecated methods kept as no-ops

## Test Plan

- [x] Run full test suite: 105 tests passing
- [x] Verify XSS prevention with 22 security tests
- [x] Integration tests for plugin bootstrap
- [x] Security audit completed (12 findings documented)
- [x] Code review completed (8.5/10 rating)

## Security Audit Summary

The security-coder agent identified improvements needed in future releases:
- Whitespace normalization in regex patterns
- JSON depth limits for API endpoint
- CSRF protection for preview API

These are documented for follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)