### PR TITLE
feat: compact mode for secondary textareas

### DIFF
--- a/css/markdown-editor.css
+++ b/css/markdown-editor.css
@@ -363,6 +363,36 @@
 }
 
 /* ============================================
+   Compact Mode (secondary textareas like status reason)
+   ============================================ */
+
+.markdown-editor-container.markdown-compact {
+    margin: 4px 0;
+    box-shadow: none;
+}
+
+.markdown-compact .markdown-toolbar {
+    padding: 4px 6px;
+    gap: 2px;
+}
+
+.markdown-compact .markdown-toolbar-btn {
+    width: 26px;
+    height: 26px;
+}
+
+.markdown-compact .markdown-toolbar-btn svg {
+    width: 14px;
+    height: 14px;
+}
+
+.markdown-compact .markdown-textarea {
+    min-height: 80px;
+    padding: 8px;
+    font-size: 13px;
+}
+
+/* ============================================
    Format Switching States
    ============================================ */
 

--- a/js/markdown-editor.js
+++ b/js/markdown-editor.js
@@ -116,7 +116,8 @@
                     'codeblock', 'ul', 'ol', 'quote', 'hr', 'image'
                 ],
                 shortcuts: true,
-                autoInit: true
+                autoInit: true,
+                compact: false // No preview, minimal toolbar - for secondary textareas
             }, options);
 
             this.container = null;
@@ -168,9 +169,8 @@
                 this.createToolbar();
             }
 
-            // Preview-Pane erstellen (nur für Markdown)
-            // Bei HTML brauchen wir keine Preview
-            if (this.currentFormat === 'markdown') {
+            // Preview-Pane erstellen (nur für Markdown, nicht im Compact-Mode)
+            if (this.currentFormat === 'markdown' && !this.options.compact) {
                 this.createPreview();
                 this.setupLivePreview();
             }
@@ -180,8 +180,8 @@
                 this.setupKeyboardShortcuts();
             }
 
-            // Image paste/drop upload (nur für Markdown)
-            if (this.currentFormat === 'markdown') {
+            // Image paste/drop upload (nur für Markdown, nicht im Compact-Mode)
+            if (this.currentFormat === 'markdown' && !this.options.compact) {
                 this.setupImageUpload();
             }
 
@@ -597,8 +597,11 @@
          * Erstellt den Container-Wrapper um die Textarea
          */
         createContainer() {
+            const containerClass = 'markdown-editor-container'
+                + (this.options.compact ? ' markdown-compact' : '');
+
             this.container = $('<div>', {
-                class: 'markdown-editor-container',
+                class: containerClass,
                 'data-format': this.currentFormat
             });
 
@@ -665,8 +668,10 @@
                 'aria-label': 'Markdown Formatting Tools'
             });
 
-            // Toolbar-Buttons erstellen
+            // Toolbar-Buttons erstellen (compact mode: skip image button)
+            const skipInCompact = ['image'];
             this.options.toolbarButtons.forEach(button => {
+                if (this.options.compact && skipInCompact.includes(button)) return;
                 const btn = this.createToolbarButton(button);
                 if (btn) {
                     this.toolbar.append(btn);
@@ -676,9 +681,11 @@
             // Note: Format-Switcher is now standalone (created in init())
             // and not part of the toolbar anymore
 
-            // Preview-Toggle Button (nur mobile)
-            const previewToggle = this.createPreviewToggle();
-            this.toolbar.append(previewToggle);
+            // Preview-Toggle Button (nur mobile, skip in compact mode)
+            if (!this.options.compact) {
+                const previewToggle = this.createPreviewToggle();
+                this.toolbar.append(previewToggle);
+            }
 
             // Toolbar vor der Textarea einfügen
             this.container.prepend(this.toolbar);
@@ -942,6 +949,9 @@
          * Rendert die Markdown-Preview
          */
         renderPreview() {
+            // Skip rendering if no preview pane (compact mode)
+            if (!this.previewPane) return;
+
             const markdown = this.textarea.val();
 
             if (!markdown.trim()) {
@@ -1939,15 +1949,17 @@
                     debugLog('Created Markdown toolbar', 'DEBUG');
                 }
 
-                // Create preview if not exists
-                if (!this.previewPane) {
+                // Create preview if not exists (skip in compact mode)
+                if (!this.previewPane && !this.options.compact) {
                     this.createPreview();
                     this.setupLivePreview();
                     debugLog('Created Markdown preview', 'DEBUG');
                 }
 
-                // Re-register image upload handlers
-                this.setupImageUpload();
+                // Re-register image upload handlers (skip in compact mode)
+                if (!this.options.compact) {
+                    this.setupImageUpload();
+                }
 
                 // Show all Markdown-specific buttons
                 if (this.toolbar) {
@@ -2113,14 +2125,32 @@
         preventRedactorReInitialization();
 
         // Suche nach osTicket Thread Entry Forms
-        const selectors = [
+        // Primary textareas get full editor (toolbar + preview)
+        const primarySelectors = [
             'textarea[name="response"]',           // Staff reply
             'textarea[name="message"]',            // New ticket message
             'textarea[name="note"]',               // Internal note
-            'textarea.richtext',                   // osTicket custom form fields with WYSIWYG
             'textarea.markdown-enabled',           // Explizit markierte Textareas
             'textarea[data-markdown="true"]'       // Data-Attribute
         ];
+
+        // Secondary textareas get compact mode (toolbar only, no preview)
+        const secondarySelectors = [
+            'textarea.richtext'                    // osTicket custom form fields with WYSIWYG
+        ];
+
+        // Combined for backward compatibility
+        const selectors = [...primarySelectors, ...secondarySelectors];
+
+        /**
+         * Check if a textarea is a primary (full editor) textarea
+         */
+        function isPrimaryTextarea($textarea) {
+            const name = $textarea.attr('name') || '';
+            return ['response', 'message', 'note'].includes(name)
+                || $textarea.hasClass('markdown-enabled')
+                || $textarea.attr('data-markdown') === 'true';
+        }
 
         /**
          * Initialize Markdown Editor for textareas
@@ -2154,11 +2184,13 @@
 
                             // If Redactor is present OR we've waited long enough, initialize
                             if (hasRedactor || attemptCount >= maxAttempts) {
-                                debugLog(`Initializing editor for textarea: ${$textarea.attr('name')} (attempt ${attemptCount})`, 'INFO');
+                                const compact = !isPrimaryTextarea($textarea);
+                                debugLog(`Initializing editor for textarea: ${$textarea.attr('name')} (attempt ${attemptCount}, compact: ${compact})`, 'INFO');
 
                                 $textarea.markdownEditor({
                                     previewPosition: 'bottom',
-                                    debounceDelay: 500
+                                    debounceDelay: 500,
+                                    compact: compact
                                 });
                             }
                         });
@@ -2239,11 +2271,13 @@
 
                             // Check if visible (might have been hidden before)
                             if ($textarea.is(':visible') || $textarea.parent().is(':visible')) {
-                                debugLog(`Initializing dynamically added textarea: ${$textarea.attr('name')}`, 'INFO');
+                                const compact = !isPrimaryTextarea($textarea);
+                                debugLog(`Initializing dynamically added textarea: ${$textarea.attr('name')} (compact: ${compact})`, 'INFO');
 
                                 $textarea.markdownEditor({
                                     previewPosition: 'bottom',
-                                    debounceDelay: 500
+                                    debounceDelay: 500,
+                                    compact: compact
                                 });
                             }
                         });


### PR DESCRIPTION
## Summary

- Secondary textareas (status change reason, custom form fields) now use a **compact editor mode** without preview pane or image upload
- Primary textareas (response, message, note) keep the full editor with toolbar + preview
- Compact mode has reduced padding, smaller toolbar buttons, and 80px min-height instead of 200px

Closes #8

## Changes

- **JS**: Added `compact` option to `MarkdownEditor`, `isPrimaryTextarea()` detection function, guard clauses for preview/image upload
- **CSS**: Added `.markdown-compact` styles for reduced footprint

## Test plan

- [ ] Open a ticket and verify the **response** textarea has full editor (toolbar + preview)
- [ ] Change ticket status (e.g. Close) and verify the **reason** textarea has compact editor (toolbar only, no preview)
- [ ] Switch format (Markdown/HTML/Text) in compact mode - should not crash
- [ ] Test on mobile - compact mode should be even smaller
- [ ] Verify dynamically loaded textareas (e.g. after Help Topic change) get correct mode

Generated with [Claude Code](https://claude.com/claude-code)